### PR TITLE
Fix typo in ran_multinomial() function template

### DIFF
--- a/ext/numo/gsl/rng/tmpl/ran_multinomial.c
+++ b/ext/numo/gsl/rng/tmpl/ran_multinomial.c
@@ -8,7 +8,7 @@
 
  */
 static VALUE
-<%=c_func(1)%>(VALUE self, VALUE vN, VALUE vp)
+<%=c_func(2)%>(VALUE self, VALUE vN, VALUE vp)
 {
     VALUE vn;
     double *p;


### PR DESCRIPTION
I have fixed a small mistake in the `ran_multinomial()` function template. This fix addresses a typo in the number of arguments for the function.